### PR TITLE
Fix P2P peer cleanup on client destruction

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -204,6 +204,9 @@ CClient::~CClient()
         Sound.Stop();
     }
 
+    // clean up any P2P connections
+    P2PManager.RemovePeers();
+
     // free audio encoders and decoders
     opus_custom_encoder_destroy ( OpusEncoderMono );
     opus_custom_decoder_destroy ( OpusDecoderMono );

--- a/src/peertopeer/p2pmanager.cpp
+++ b/src/peertopeer/p2pmanager.cpp
@@ -2,6 +2,11 @@
 
 CP2PManager::CP2PManager ( QObject* parent ) : QObject ( parent ) {}
 
+CP2PManager::~CP2PManager()
+{
+    RemovePeers();
+}
+
 void CP2PManager::AddPeer ( const QHostAddress& addr, quint16 port )
 {
     auto* peer = new CPeerConnection ( this );

--- a/src/peertopeer/p2pmanager.h
+++ b/src/peertopeer/p2pmanager.h
@@ -35,6 +35,7 @@ class CP2PManager : public QObject
 
 public:
     explicit CP2PManager ( QObject* parent = nullptr );
+    ~CP2PManager();
 
     void AddPeer ( const QHostAddress& addr, quint16 port );
     void RemovePeers();


### PR DESCRIPTION
## Summary
- clean up peers inside `CP2PManager` via a new destructor
- explicitly remove peers when `CClient` is destroyed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a359e89cc832ab0cfcd7352dad86a