### PR TITLE
Update translations for P2P checkbox

### DIFF
--- a/src/translation/translation_de_DE.ts
+++ b/src/translation/translation_de_DE.ts
@@ -2742,6 +2742,11 @@ Wir haben Deinen Kanal stummgeschaltet und die Funktion &apos;Stummschalten&apos
         <translation>Audiohinweise</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Audio-/Netzwerk-Einstellungen</translation>

--- a/src/translation/translation_es_ES.ts
+++ b/src/translation/translation_es_ES.ts
@@ -2770,6 +2770,11 @@ Hemos silenciado tu canal y activado &apos;Silenciarme Yo&apos;. Por favor resue
         <translation>Alertas Sonoras</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Configuración Audio/Red</translation>

--- a/src/translation/translation_fr_FR.ts
+++ b/src/translation/translation_fr_FR.ts
@@ -2382,6 +2382,11 @@ Nous avons coupé votre canal et activé &quot;Me silencer&quot;. Veuillez d&apo
         <translation>Alertes audio</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Configuration audio/réseau</translation>

--- a/src/translation/translation_it_IT.ts
+++ b/src/translation/translation_it_IT.ts
@@ -2731,6 +2731,11 @@ E&apos; stato disattivato l&apos;audio del tuo canale ed inserito il &quot;Disat
         <translation>Avvisi Audio</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Impostazioni Audio/Rete</translation>

--- a/src/translation/translation_ko_KR.ts
+++ b/src/translation/translation_ko_KR.ts
@@ -2382,6 +2382,11 @@ We muted your channel and activated &apos;Mute Myself&apos;. Please solve the fe
         <translation>오디오 경고</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>오디오/네트워크 설정</translation>

--- a/src/translation/translation_nb_NO.ts
+++ b/src/translation/translation_nb_NO.ts
@@ -2002,6 +2002,11 @@ We muted your channel and activated &apos;Mute Myself&apos;. Please solve the fe
         <translation>Lydvarsler</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Enable</source>
         <translation type="vanished">Skru på</translation>
     </message>

--- a/src/translation/translation_nl_NL.ts
+++ b/src/translation/translation_nl_NL.ts
@@ -2722,6 +2722,11 @@ We hebben uw kanaal gedempt en &apos;Demp mijzelf&apos; geactiveerd. Los eerst h
         <translation>Audiowaarschuwingen</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Audio-/netwerk-instellingen</translation>

--- a/src/translation/translation_pl_PL.ts
+++ b/src/translation/translation_pl_PL.ts
@@ -2422,6 +2422,11 @@ Twój kanał został wyciszony i włączono „Wycisz mnie”. Napraw przyczynę
         <translation>Alarmy dźwiękowe</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Ustawienia dźwięku/sieci</translation>

--- a/src/translation/translation_pt_BR.ts
+++ b/src/translation/translation_pt_BR.ts
@@ -2760,6 +2760,11 @@ Silenciamos seu canal e ativamos &apos;Silenciar-me&apos;. Resolva o problema de
         <translation>Alertas de Áudio</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Configuração de Áudio/Rede</translation>

--- a/src/translation/translation_pt_PT.ts
+++ b/src/translation/translation_pt_PT.ts
@@ -2718,6 +2718,11 @@ O seu canal foi silenciado e foi activada a função &apos;Silenciar-me&apos;. P
         <translation>Alertas de Áudio</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Configuração Audio/Rede</translation>

--- a/src/translation/translation_sk_SK.ts
+++ b/src/translation/translation_sk_SK.ts
@@ -2318,6 +2318,11 @@ Stíšili sme váš kanál a aktivovali nastavenia &apos;Stíšiť ma&apos;. Pro
         <translation>Zvukové upozornenia</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Nastavenie zvuku/siete</translation>

--- a/src/translation/translation_sv_SE.ts
+++ b/src/translation/translation_sv_SE.ts
@@ -2433,6 +2433,11 @@ Vi stängde av din kanal och aktiverade &apos;Tysta mig själv&apos;. Vänligen 
         <translation>Ljudvarningar</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>Ljud och nätverksinställningar</translation>

--- a/src/translation/translation_th.ts
+++ b/src/translation/translation_th.ts
@@ -2735,6 +2735,11 @@ We muted your channel and activated &apos;Mute Myself&apos;. Please solve the fe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation type="unfinished"></translation>

--- a/src/translation/translation_zh_CN.ts
+++ b/src/translation/translation_zh_CN.ts
@@ -2204,6 +2204,11 @@ We muted your channel and activated &apos;Mute Myself&apos;. Please solve the fe
         <translation>音频警报</translation>
     </message>
     <message>
+        <location filename="../clientsettingsdlgbase.ui" line="348"/>
+        <source>Enable P2P Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../clientsettingsdlgbase.ui" line="366"/>
         <source>Audio/Network Setup</source>
         <translation>音频/网络选项</translation>


### PR DESCRIPTION
## Summary
- ensure `Enable P2P Mode` string is present in all translation `.ts` files
- regenerate translation `.qm` files locally

## Testing
- `lrelease Jamulus.pro`
- `bash tools/check-wininstaller-translations.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a36890edc832a86c9cf7d3e45e551