### PR TITLE
Fix P2P audio packet length

### DIFF
--- a/src/peertopeer/peerconnection.cpp
+++ b/src/peertopeer/peerconnection.cpp
@@ -28,7 +28,9 @@ void CPeerConnection::OnReadyRead()
         const qint64 len = Socket.readDatagram ( reinterpret_cast<char*> ( &RecvBuffer[0] ), MAX_SIZE_BYTES_NETW_BUF );
         if ( len > 0 )
         {
-            emit AudioPacketReceived ( RecvBuffer );
+            CVector<uint8_t> data ( static_cast<int> ( len ) );
+            std::copy_n ( RecvBuffer.begin(), len, data.begin() );
+            emit AudioPacketReceived ( data );
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure peer audio reception only emits bytes actually read

## Testing
- `qmake "CONFIG+=headless"`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685a3c203e8c832abd126d6ea48f94c0