### PR TITLE
Ensure peer cleanup when disabling P2P mode

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -44,6 +44,7 @@
 #include "signalhandler.h"
 
 class CClientSettings;
+class CClientSettingsDlg;
 
 #if defined( _WIN32 ) && !defined( JACK_ON_WINDOWS )
 #    include "sound/asio/sound.h"
@@ -125,6 +126,8 @@ public:
 class CClient : public QObject
 {
     Q_OBJECT
+
+    friend class CClientSettingsDlg;
 
 public:
     CClient ( const quint16  iPortNumber,

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -1222,4 +1222,13 @@ void CClientSettingsDlg::OnAudioPanValueChanged ( int value )
     UpdateAudioFaderSlider();
 }
 
-void CClientSettingsDlg::OnP2PModeChanged ( int value ) { pSettings->bUseP2PMode = value == Qt::Checked; }
+void CClientSettingsDlg::OnP2PModeChanged ( int value )
+{
+    if ( value != Qt::Checked )
+    {
+        // Clean up any existing peer connections when disabling P2P mode
+        pClient->P2PManager.RemovePeers();
+    }
+
+    pSettings->bUseP2PMode = value == Qt::Checked;
+}


### PR DESCRIPTION
## Summary
- clean existing P2P peers when disabling mode
- allow settings dialog access to client's P2PManager

## Testing
- `qmake Jamulus.pro`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685a3f3a854c832a9dd5eeef89fc9570