### PR TITLE
Add peer setup when receiving client list

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -147,7 +147,7 @@ CClient::CClient ( const quint16  iPortNumber,
 
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLRedServerListReceived, this, &CClient::CLRedServerListReceived );
 
-    QObject::connect ( &ConnLessProtocol, &CProtocol::CLConnClientsListMesReceived, this, &CClient::CLConnClientsListMesReceived );
+    QObject::connect ( &ConnLessProtocol, &CProtocol::CLConnClientsListMesReceived, this, &CClient::OnCLConnClientsListMesReceived );
 
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLPingReceived, this, &CClient::OnCLPingReceived );
 
@@ -315,6 +315,23 @@ void CClient::OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint
     {
         emit CLChannelLevelListReceived ( InetAddr, vecLevelList );
     }
+}
+
+void CClient::OnCLConnClientsListMesReceived ( CHostAddress inetAddr, CVector<CChannelInfo> vecChanInfo )
+{
+    if ( pSettings && pSettings->bUseP2PMode )
+    {
+        for ( const auto& chanInfo : vecChanInfo )
+        {
+            // avoid adding ourselves as a peer
+            if ( chanInfo.iChanID != clientChannels[0].iServerChannelID )
+            {
+                P2PManager.AddPeer ( inetAddr.InetAddr, inetAddr.iPort );
+            }
+        }
+    }
+
+    emit CLConnClientsListMesReceived ( inetAddr, vecChanInfo );
 }
 
 void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )

--- a/src/client.h
+++ b/src/client.h
@@ -452,6 +452,7 @@ protected slots:
     void OnClientIDReceived ( int iServerChanID );
     void OnMuteStateHasChangedReceived ( int iServerChanID, bool bIsMuted );
     void OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
+    void OnCLConnClientsListMesReceived ( CHostAddress inetAddr, CVector<CChannelInfo> vecChanInfo );
     void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
 
 signals:


### PR DESCRIPTION
## Summary
- add new slot `OnCLConnClientsListMesReceived` in client class
- wire protocol signal to the slot
- add peers when P2P mode is enabled before forwarding signal

## Testing
- `qmake Jamulus.pro -o Makefile`
- `make -j2` *(build output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_685a536e445c832aa848110536dd9f40