### PR TITLE
Add connection logs for P2P and server

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -288,6 +288,8 @@ void CClient::OnJittBufSizeChanged ( int iNewJitBufSize )
 
 void CClient::OnNewConnection()
 {
+    qInfo() << qUtf8Printable ( QString ( "> Connected to server %1" ).arg ( Channel.GetAddress().toString() ) );
+
     // a new connection was successfully initiated, send infos and request
     // connected clients list
     Channel.SetRemoteInfo ( ChannelInfo );
@@ -633,6 +635,7 @@ bool CClient::SetServerAddr ( QString strNAddr )
     {
         // apply address to the channel
         Channel.SetAddress ( HostAddress );
+        qInfo() << qUtf8Printable ( QString ( "> Set server address to %1" ).arg ( HostAddress.toString() ) );
 
         return true;
     }
@@ -1433,6 +1436,13 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
 
     const bool bPureP2PActive = pSettings && pSettings->bUseP2PMode && pSettings->bPureP2PMode &&
                                 ( PeerStreams.size() >= std::max(0, iActiveChannels - 1) );
+
+    static bool bLastPureP2P = false;
+    if ( bPureP2PActive != bLastPureP2P )
+    {
+        qInfo() << qUtf8Printable ( QString ( "> Pure P2P %1" ).arg ( bPureP2PActive ? "enabled" : "disabled" ) );
+        bLastPureP2P = bPureP2PActive;
+    }
 
     if ( bPureP2PActive )
     {

--- a/src/peertopeer/p2pmanager.cpp
+++ b/src/peertopeer/p2pmanager.cpp
@@ -17,12 +17,14 @@ void CP2PManager::AddPeer ( const QHostAddress& addr, quint16 port )
                       this,
                       &CP2PManager::PeerAudioReceived );
     Peers.append ( peer );
+    qInfo() << qUtf8Printable ( QString ( "> Added peer %1:%2" ).arg ( addr.toString() ).arg ( port ) );
 }
 
 void CP2PManager::RemovePeers()
 {
     qDeleteAll ( Peers );
     Peers.clear();
+    qInfo() << "> Removed all peers";
 }
 
 void CP2PManager::SendAudioToPeers ( const CVector<uint8_t>& data )


### PR DESCRIPTION
## Summary
- log server address when connecting
- log when a peer connection is added or all peers removed
- print the server address once a connection is established
- report when pure P2P mode becomes active or disabled

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ae71af0832a89fbffbdfcecb5c7